### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/Front/src/MyMapComponent.js
+++ b/Front/src/MyMapComponent.js
@@ -216,7 +216,7 @@ function MyMapComponent() {
         <LayersControl.BaseLayer checked name="OpenStreetMap">
           <TileLayer
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
           />
         </LayersControl.BaseLayer>
         <LayersControl.BaseLayer checked name="Google Карта">


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}.`), see

https://github.com/openstreetmap/operations/issues/737